### PR TITLE
Add remaining implementation of AudioModel API

### DIFF
--- a/src/audiomodel.cpp
+++ b/src/audiomodel.cpp
@@ -7,16 +7,88 @@ AudioModel::AudioModel(QObject *parent) : QObject(parent)
 
 }
 
+/**
+ *  Returns the FFT of the specified complex array.
+ *
+ *  @param  x the complex array
+ *  @return the FFT of the complex array <tt>x</tt>
+ */
 QVector<complex<double>> AudioModel::fft(QVector<complex<double> > x)
 {
-    return QVector<complex<double>>();
+    int N = x.length();
+
+    // base case
+    if (N == 1) return QVector<complex<double>> { x[0] };
+
+    // radix 2 Cooley-Tukey FFT
+    if (N % 2 != 0) {
+        throw invalid_argument("N is not a power of 2");
+    }
+
+    // fft of even terms
+    QVector<complex<double>> even = QVector<complex<double>>(N/2);
+    for (int k = 0; k < N/2; k++) {
+        even[k] = x[2*k];
+    }
+    QVector<complex<double>> q = fft(even);
+
+    // fft of odd terms
+    QVector<complex<double>> odd  = even;  // reuse the array
+    for (int k = 0; k < N/2; k++) {
+        odd[k] = x[2*k + 1];
+    }
+    QVector<complex<double>> r = fft(odd);
+
+    // combine
+    QVector<complex<double>> y = QVector<complex<double>>(N);
+    for (int k = 0; k < N/2; k++) {
+        double kth = -2 * k * M_PI / N;
+        complex<double> wk = complex<double>(cos(kth), sin(kth));
+        y[k]       = q[k]+(wk * r[k]);
+        y[k + N/2] = q[k]-(wk * r[k]);
+    }
+    return y;
 }
 
+/**
+ *  Returns the inverse FFT of the specified complex array.
+ *
+ *  @param  x the complex array
+ *  @return the inverse FFT of the complex array <tt>x</tt>
+ */
 QVector<complex<double>> AudioModel::ifft(QVector<complex<double> > x)
 {
-    return QVector<complex<double>>();
+    int N = x.length();
+    QVector<complex<double>> y = QVector<complex<double>>(N);
+
+    // take conjugate
+    for (int i = 0; i < N; i++) {
+        y[i] = conj(x[i]);
+    }
+
+    // compute forward FFT
+    y = fft(y);
+
+    // take conjugate again
+    for (int i = 0; i < N; i++) {
+        y[i] = conj(y[i]);
+    }
+
+    // divide by N
+    for (int i = 0; i < N; i++) {
+        y[i] = y[i] * (1.0 / N);
+    }
+
+    return y;
 }
 
+/**
+ *  Returns the linear convolution of the two specified complex arrays.
+ *
+ *  @param  x one complex array
+ *  @param  y the other complex array
+ *  @return the linear convolution of <tt>x</tt> and <tt>y</tt>
+ */
 QVector<complex<double>> AudioModel::convolve(QVector<std::complex<double> > x, QVector<std::complex<double> > y)
 {
     QVector<complex<double>> a = QVector<complex<double>>(2*x.length());
@@ -34,6 +106,13 @@ QVector<complex<double>> AudioModel::convolve(QVector<std::complex<double> > x, 
     return cconvolve(a, b);
 }
 
+/**
+ *  Returns the circular convolution of the two specified complex arrays.
+ *
+ *  @param  x one complex array
+ *  @param  y the other complex array
+ *  @return the circular convolution of <tt>x</tt> and <tt>y</tt>
+ */
 QVector<complex<double>> AudioModel::cconvolve(QVector<std::complex<double> > x, QVector<std::complex<double> > y)
 {
     // TODO: should probably pad x and y with 0s so that they have same length
@@ -56,4 +135,24 @@ QVector<complex<double>> AudioModel::cconvolve(QVector<std::complex<double> > x,
 
     // compute inverse FFT
     return ifft(c);
+}
+
+/**
+ *  This method calculates the signal power from the FFT.
+ *
+ *  @param x The FFT of the original signal,
+ *  @param original_length The original length of the input data table.
+ *
+ *  @return The power of signal calculation by Parseval's theorem.
+ */
+double AudioModel::computeLevel(QVector<std::complex<double>> x, int original_length)
+{
+    double result = 0;
+    int i;
+    double fraction;
+    for(i=0; i<x.length(); i++)
+       result += abs(x[i]) * abs(x[i]);
+    fraction = (double)x.length()/(double)original_length;
+    result = result*fraction;
+    return result;
 }

--- a/src/audiomodel.h
+++ b/src/audiomodel.h
@@ -20,6 +20,8 @@ public:
 
     QVector<complex<double>> fft(QVector<complex<double>> x);
     QVector<complex<double>> ifft(QVector<complex<double>> x);
+
+    double computeLevel(QVector<complex<double>> x, int original_length);
 signals:
 
 public slots:


### PR DESCRIPTION
- fft, ifft and computeLevel are implemented now,
- implementation is based on auxiliary materials given by the teacher,
- documentation has been added too.